### PR TITLE
Fixes NSRegularExpression initializer

### DIFF
--- a/Markingbird/Markdown.swift
+++ b/Markingbird/Markdown.swift
@@ -1780,7 +1780,7 @@ private struct MarkdownRegex {
 #endif
         
         var error: NSError?
-        let re = NSRegularExpression.regularExpressionWithPattern(pattern,
+        let re = NSRegularExpression(pattern: pattern,
             options: options,
             error: &error)
         


### PR DESCRIPTION
It looks like the `regularExpressionWithPattern` class method no longer exists, and is instead an initializer method.
