### PR TITLE
Fix for issue #2

### DIFF
--- a/Markingbird/Markdown.swift
+++ b/Markingbird/Markdown.swift
@@ -1669,12 +1669,15 @@ public struct Markdown {
                 line = ""
                 valid = false
             case "\r":
-                if (i.advancedBy(1) < text.endIndex) && (text[i.advancedBy(1)] != "\n") {
-                    if (valid) { output += line }
-                    output += "\n"
-                    line = ""
-                    valid = false
-                }
+                if (valid) { output += line }
+                output += "\n"
+                line = ""
+                valid = false
+            case "\r\n":
+                if (valid) { output += line }
+                output += "\n"
+                line = ""
+                valid = false
             case "\t":
                 let width = Markdown._tabWidth - line.characters.count % Markdown._tabWidth
                 for _ in 0..<width {

--- a/Markingbird/Markdown.swift
+++ b/Markingbird/Markdown.swift
@@ -1650,7 +1650,7 @@ public struct Markdown {
 
         return sb
     }
-
+    
     /// convert all tabs to _tabWidth spaces;
     /// standardizes line endings from DOS (CR LF) or Mac (CR) to UNIX (LF);
     /// makes sure text ends with a couple of newlines;
@@ -1659,42 +1659,32 @@ public struct Markdown {
         var output = ""
         var line = ""
         var valid = false
-
-        let str = text as NSString
-        for i in 0..<str.length {
-            let c = str.characterAtIndex(i)
+        
+        for i in text.startIndex..<text.endIndex {
+            let c = text[i]
             switch (c) {
-            case U16_NEWLINE:
+            case "\n":
                 if (valid) { output += line }
                 output += "\n"
                 line = ""
                 valid = false
-            case U16_RETURN:
-                if (i < str.length - 1) && (str.characterAtIndex(i + 1) != 10) {
-                    if (valid) { output += line }
-                    output += "\n"
-                    line = ""
-                    valid = false
-                }
-            case U16_TAB:
+            case "\t":
                 let width = Markdown._tabWidth - line.characters.count % Markdown._tabWidth
                 for _ in 0..<width {
                     line += " "
                 }
-            case 0x1A:
-                break
             default:
-                if !valid && c != U16_SPACE /* ' ' */ {
+                if !valid && c != " " /* ' ' */ {
                     valid = true
                 }
-                line += String(count: 1, repeatedValue: UnicodeScalar(c))
+                line += String(count: 1, repeatedValue: c)
                 break
             }
         }
-
+        
         if (valid) { output += line }
         output += "\n"
-
+        
         // add two newlines to the end before return
         return output + "\n\n"
     }

--- a/Markingbird/Markdown.swift
+++ b/Markingbird/Markdown.swift
@@ -1668,6 +1668,13 @@ public struct Markdown {
                 output += "\n"
                 line = ""
                 valid = false
+            case "\r":
+                if (i.advancedBy(1) < text.endIndex) && (text[i.advancedBy(1)] != "\n") {
+                    if (valid) { output += line }
+                    output += "\n"
+                    line = ""
+                    valid = false
+                }
             case "\t":
                 let width = Markdown._tabWidth - line.characters.count % Markdown._tabWidth
                 for _ in 0..<width {

--- a/MarkingbirdTests/SimpleTests.swift
+++ b/MarkingbirdTests/SimpleTests.swift
@@ -193,4 +193,34 @@ class SimpleTests: XCTestCase {
         
         XCTAssertEqual(expected, actual)
     }
+    
+    func testNormalizeCR()
+    {
+        let input = "# Header\r\rBody"
+        let expected = "<h1>Header</h1>\n\n<p>Body</p>\n"
+        
+        let actual = m.transform(input)
+        
+        XCTAssertEqual(expected, actual)
+    }
+    
+    func testNormalizeCRLF()
+    {
+        let input = "# Header\r\n\r\nBody"
+        let expected = "<h1>Header</h1>\n\n<p>Body</p>\n"
+        
+        let actual = m.transform(input)
+        
+        XCTAssertEqual(expected, actual)
+    }
+    
+    func testNormalizeLF()
+    {
+        let input = "# Header\n\nBody"
+        let expected = "<h1>Header</h1>\n\n<p>Body</p>\n"
+        
+        let actual = m.transform(input)
+        
+        XCTAssertEqual(expected, actual)
+    }
 }


### PR DESCRIPTION
Fix for issues with Unicode scalar values in normalize function. 

```fatal error: high- and low-surrogate code points are not valid Unicode scalar values (lldb)```

I ran into this and made an attempt to fix it by replacing the `String`/`NSString`-mixed implementation with an all `String` variant 

It passes all the tests provided in `mstest-0.1/` and has 100% code coverage. All other tests are unaffected. It also works with the markdown that previously crashed it. 