### PR TITLE
Swift 4 update

### DIFF
--- a/Markingbird/Markdown.swift
+++ b/Markingbird/Markdown.swift
@@ -267,7 +267,7 @@ public struct Markdown {
 
         var backslashPattern = ""
 
-        for c in "\\`*_{}[]()>#+-.!/".characters {
+        for c in "\\`*_{}[]()>#+-.!/" {
             let key = String(c)
             let hash = Markdown.getHashKey(key, isHtmlBlock: false)
             _escapeTable[key] = hash
@@ -1673,7 +1673,7 @@ public struct Markdown {
         var line = ""
         var valid = false
         
-        for i in text.characters.indices {
+        for i in text.indices {
             let c = text[i]
             switch (c) {
             case "\n":
@@ -1692,7 +1692,7 @@ public struct Markdown {
                 line = ""
                 valid = false
             case "\t":
-                let width = Markdown._tabWidth - line.characters.count % Markdown._tabWidth
+                let width = Markdown._tabWidth - line.count % Markdown._tabWidth
                 for _ in 0..<width {
                     line += " "
                 }
@@ -1968,7 +1968,7 @@ private struct MarkdownRegexMatch {
 
     func valueOfGroupAtIndex(_ idx: Int) -> NSString {
         if 0 <= idx && idx < textCheckingResult.numberOfRanges {
-            let groupRange = textCheckingResult.rangeAt(idx)
+            let groupRange = textCheckingResult.range(at: idx)
             if (groupRange.location == NSNotFound) {
                 return ""
             }


### PR DESCRIPTION
Remove deprecated usage of the characters array
```swift
String.characters
```